### PR TITLE
feat: show description text below title in the forms

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -346,6 +346,9 @@ AT.prototype.texts = {
     verifyEmail: "",
     resendVerificationEmail: "Send the verification email again",
   },
+  description: {
+    forgotPwd: "emailResetText",
+  }
 };
 
 AT.prototype.SPECIAL_FIELDS = [

--- a/lib/templates_helpers/at_title.js
+++ b/lib/templates_helpers/at_title.js
@@ -4,4 +4,9 @@ AT.prototype.atTitleHelpers = {
     var state = (parentData && parentData.state) || AccountsTemplates.getState();
     return T9n.get(AccountsTemplates.texts.title[state], markIfMissing = false);
   },
+  description() {
+    var parentData = Template.currentData();
+    var state = (parentData && parentData.state) || AccountsTemplates.getState();
+    return T9n.get(AccountsTemplates.texts.description[state], markIfMissing = false);
+  }
 };


### PR DESCRIPTION
- now there's text only set for "forgot password form"
  these texts are retrieved from t9n package