### PR TITLE
fix: disable margin-bottom for verify email alert messages

### DIFF
--- a/lib/templates_helpers/at_form.js
+++ b/lib/templates_helpers/at_form.js
@@ -63,3 +63,8 @@ AT.prototype.atFormHelpers = {
         return (state === "signIn" || state === "forgotPwd") && AccountsTemplates.options.showResendVerificationEmailLink;
     },
 };
+
+Template.registerHelper('verifyEmailAlertNoMargin', function (next_state) {
+  var state = next_state || this.state || AccountsTemplates.getState();
+  return state === 'verifyEmail'
+});


### PR DESCRIPTION
fixing margin when verify-email template is shown for 2 seconds

then the .alert component without margin is in the center